### PR TITLE
Fix :bug: in saving survey results that aren't contiguous

### DIFF
--- a/src/app/domain/questions.py
+++ b/src/app/domain/questions.py
@@ -70,7 +70,11 @@ def get_survey_page_for_user_id(page_num, user_id):
     # Rectify the page with the user's answers and return a list.
     for question in survey_page:
         try:
-            user_answer = user_answers[question.question_number - 1].answer
+            if user_answers[question.question_number - 1].question_number == question.question_number:
+                user_answer = user_answers[question.question_number - 1].answer
+            else:
+                user_answer = None
+                user_answers.insert(question.question_number - 1, None)
         except IndexError:
             user_answer = None
         questions.append({

--- a/src/app/domain/questions.py
+++ b/src/app/domain/questions.py
@@ -14,12 +14,13 @@ def save_user_submitted_answers(user_id, submitted):
 
     if type(submitted) == list and len(submitted) > 0:
         questions_start = submitted[0].question_number - 1
-        questions_end = questions_start + len(submitted)
+        questions_end = submitted[-1].question_number
     else:
         return
 
     for question in quiz_attempt.questions[questions_start:questions_end]:
-        quiz_attempt.questions[question.question_number - 1].answer = submitted.pop(0).answer
+        if question.question_number == submitted[0].question_number:
+            quiz_attempt.questions[question.question_number - 1].answer = submitted.pop(0).answer
 
     quiz_attempt.questions.extend(submitted)
     quiz_attempt.put()

--- a/test/domain/questions_test.py
+++ b/test/domain/questions_test.py
@@ -17,31 +17,34 @@ class GetFirstSurveyPageForUserIdTests(GaeTestCase):
             get_first_survey_page_for_user_id(None)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_QuizAttempt_get_user_by_id_called_with_user_id_passed_in(self, attempt_mock):
+    def test_QuizAttempt_get_user_by_id_called_with_user_id_passed_in(self, quiz_attempt_get_by_user_id_mock):
         get_first_survey_page_for_user_id(1234)
-        attempt_mock.assert_called_once_with(1234)
+        quiz_attempt_get_by_user_id_mock.assert_called_once_with(1234)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_QuizAttempt_with_0_questions_in_it_will_return_page_one(self, attempt_mock):
-        attempt_mock.return_value.questions = []
+    def test_QuizAttempt_with_0_questions_in_it_will_return_page_one(self, quiz_attempt_get_by_user_id_mock):
+        quiz_attempt_get_by_user_id_mock.return_value.questions = []
         first_page = get_first_survey_page_for_user_id(1234)
         self.assertEqual(1, first_page)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_QuizAttempt_with_20_questions_in_it_will_return_page_two(self, attempt_mock):
-        attempt_mock.return_value.questions = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+    def test_QuizAttempt_with_20_questions_in_it_will_return_page_two(self, quiz_attempt_get_by_user_id_mock):
+        quiz_attempt_get_by_user_id_mock.return_value.questions = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+                                                                   1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
         first_page = get_first_survey_page_for_user_id(1234)
         self.assertEqual(2, first_page)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_QuizAttempt_with_24_questions_in_it_will_return_page_two(self, attempt_mock):
-        attempt_mock.return_value.questions = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4]
+    def test_QuizAttempt_with_24_questions_in_it_will_return_page_two(self, quiz_attempt_get_by_user_id_mock):
+        quiz_attempt_get_by_user_id_mock.return_value.questions = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+                                                                   1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
+                                                                   1, 2, 3, 4]
         first_page = get_first_survey_page_for_user_id(1234)
         self.assertEqual(2, first_page)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_QuizAttempt_with_44_questions_in_it_will_return_page_three(self, attempt_mock):
-        attempt_mock.return_value.questions = [
+    def test_QuizAttempt_with_44_questions_in_it_will_return_page_three(self, quiz_attempt_get_by_user_id_mock):
+        quiz_attempt_get_by_user_id_mock.return_value.questions = [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
             1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
             1, 2, 3, 4, 5, 6, 7, 8, 9, 0,
@@ -66,25 +69,25 @@ class GetSurveyPageTests(GaeTestCase):
             get_survey_page("one")
 
     @mock.patch('app.domain.questions._calculate_from_and_to_for_page_number')
-    def test_page_num_is_converted_to_integer(self, number_mock):
-        number_mock.return_value = (1, 20)
+    def test_page_num_is_converted_to_integer(self, calculate_page_number_mock):
+        calculate_page_number_mock.return_value = (1, 20)
         get_survey_page("1")
-        number_mock.assert_called_once_with(1)
+        calculate_page_number_mock.assert_called_once_with(1)
 
     @mock.patch('app.domain.questions.Question.get_questions_by_number_range')
-    def test_page_num_1_returns_questions_1_to_20(self, questions_mock):
+    def test_page_num_1_returns_questions_1_to_20(self, get_questions_by_number_range_mock):
         get_survey_page(1)
-        questions_mock.assert_called_once_with(1, 20)
+        get_questions_by_number_range_mock.assert_called_once_with(1, 20)
 
     @mock.patch('app.domain.questions.Question.get_questions_by_number_range')
-    def test_page_num_2_returns_questions_21_to_40(self, questions_mock):
+    def test_page_num_2_returns_questions_21_to_40(self, get_questions_by_number_range_mock):
         get_survey_page(2)
-        questions_mock.assert_called_once_with(21, 40)
+        get_questions_by_number_range_mock.assert_called_once_with(21, 40)
 
     @mock.patch('app.domain.questions.Question.get_questions_by_number_range')
-    def test_page_num_4_returns_questions_61_to_80(self, questions_mock):
+    def test_page_num_4_returns_questions_61_to_80(self, get_questions_by_number_range_mock):
         get_survey_page(4)
-        questions_mock.assert_called_once_with(61, 80)
+        get_questions_by_number_range_mock.assert_called_once_with(61, 80)
 
 
 class GetSurveyPageForUserIdTests(GaeTestCase):
@@ -102,41 +105,30 @@ class GetSurveyPageForUserIdTests(GaeTestCase):
         self.question2.question_number = 2
 
     @mock.patch('app.domain.questions.get_survey_page')
-    def test_get_survey_page_gets_called(self, survey_mock):
+    def test_get_survey_page_gets_called(self, get_survey_page_mock):
         get_survey_page_for_user_id(1, 1)
-        survey_mock.assert_called_once_with(1)
+        get_survey_page_mock.assert_called_once_with(1)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_gets_the_quiz_attempt_for_the_user_id_param(self, attempt_mock):
+    def test_gets_the_quiz_attempt_for_the_user_id_param(self, quiz_attempt_get_by_user_id_mock):
         get_survey_page_for_user_id(1, 1)
-        attempt_mock.assert_called_once_with(1)
+        quiz_attempt_get_by_user_id_mock.assert_called_once_with(1)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
     @mock.patch('app.domain.questions.Question.get_questions_by_number_range')
-    def test_fills_in_answers_and_returns_list_of_dictionaries(self, questions_mock, attempt_mock):
-
+    def test_fills_in_answers_and_returns_list_of_dictionaries(self, questions_mock, quiz_attempt_get_by_user_id_mock):
         questions_mock.return_value = [
             self.question1,
             self.question2
         ]
-        attempt_mock.return_value.questions = [
+        quiz_attempt_get_by_user_id_mock.return_value.questions = [
             QuizAttemptAnswer(question_number=1, answer=0),
             QuizAttemptAnswer(question_number=2, answer=5)
         ]
         actual, _, _ = get_survey_page_for_user_id(1, 1)
         expected = [
-            {
-                "question_number": 1,
-                "text": "Fake text",
-                "answer": 0,
-                "category": "adm"
-            },
-            {
-                "question_number": 2,
-                "text": "Fake text",
-                "answer": 5,
-                "category": "fai",
-            }
+            {"question_number": 1, "text": "Fake text", "answer": 0, "category": "adm"},
+            {"question_number": 2, "text": "Fake text", "answer": 5, "category": "fai"}
         ]
         self.assertEqual(expected, actual)
 
@@ -149,24 +141,16 @@ class GetSurveyPageForUserIdTests(GaeTestCase):
 
         actual, _, _ = get_survey_page_for_user_id(1, 1)
         expected = [
-            {
-                "question_number": 1,
-                "text": "Fake text",
-                "answer": None,
-                "category": "adm"
-            },
-            {
-                "question_number": 2,
-                "text": "Fake text",
-                "answer": None,
-                "category": "fai",
-            }
+            {"question_number": 1, "text": "Fake text", "answer": None, "category": "adm"},
+            {"question_number": 2, "text": "Fake text", "answer": None, "category": "fai"}
         ]
         self.assertEqual(expected, actual)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
     @mock.patch('app.domain.questions.Question.get_questions_by_number_range')
-    def test_None_returned_after_end_of_questions_user_has_already_answered(self, questions_mock, attempt_mock):
+    def test_None_returned_after_end_of_questions_user_has_already_answered(self,
+                                                                            questions_mock,
+                                                                            quiz_attempt_get_by_user_id_mock):
         question3 = Question(text="Something", question_number=3, category="adm")
         questions_mock.return_value = [
             self.question1,
@@ -174,37 +158,22 @@ class GetSurveyPageForUserIdTests(GaeTestCase):
             question3
         ]
 
-        attempt_mock.return_value.questions = [
+        quiz_attempt_get_by_user_id_mock.return_value.questions = [
             QuizAttemptAnswer(question_number=1, answer=0),
             QuizAttemptAnswer(question_number=2, answer=5)
         ]
 
         actual, _, _ = get_survey_page_for_user_id(1, 1)
         expected = [
-            {
-                "question_number": 1,
-                "text": "Fake text",
-                "answer": 0,
-                "category": "adm"
-            },
-            {
-                "question_number": 2,
-                "text": "Fake text",
-                "answer": 5,
-                "category": "fai",
-            },
-            {
-                "question_number": 3,
-                "text": "Something",
-                "answer": None,
-                "category": "adm",
-            }
+            {"question_number": 1, "text": "Fake text", "answer": 0, "category": "adm"},
+            {"question_number": 2, "text": "Fake text", "answer": 5, "category": "fai"},
+            {"question_number": 3, "text": "Something", "answer": None, "category": "adm"}
         ]
         self.assertEqual(expected, actual)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
     @mock.patch('app.domain.questions.Question.get_questions_by_number_range')
-    def test_no_answer_filled_in_if_question_has_not_been_answered_yet(self, questions_mock, attempt_mock):
+    def test_no_answer_filled_in_if_question_has_not_been_answered_yet(self, questions_mock, quiz_attempt_get_by_user_id_mock):
         question3 = Question(text="Something", question_number=3, category="adm")
         questions_mock.return_value = [
             self.question1,
@@ -212,31 +181,16 @@ class GetSurveyPageForUserIdTests(GaeTestCase):
             question3
         ]
 
-        attempt_mock.return_value.questions = [
+        quiz_attempt_get_by_user_id_mock.return_value.questions = [
             QuizAttemptAnswer(question_number=1, answer=0),
             QuizAttemptAnswer(question_number=3, answer=5)
         ]
 
         actual, _, _ = get_survey_page_for_user_id(1, 1)
         expected = [
-            {
-                "question_number": 1,
-                "text": "Fake text",
-                "answer": 0,
-                "category": "adm"
-            },
-            {
-                "question_number": 2,
-                "text": "Fake text",
-                "answer": None,
-                "category": "fai",
-            },
-            {
-                "question_number": 3,
-                "text": "Something",
-                "answer": 5,
-                "category": "adm",
-            }
+            {"question_number": 1, "text": "Fake text", "answer": 0, "category": "adm"},
+            {"question_number": 2, "text": "Fake text", "answer": None, "category": "fai"},
+            {"question_number": 3, "text": "Something", "answer": 5, "category": "adm"}
         ]
         self.assertEqual(expected, actual)
 
@@ -258,24 +212,16 @@ class GetSurveyPageForUserIdTests(GaeTestCase):
 
         actual, _, _ = get_survey_page_for_user_id(2, 1)
         expected = [
-            {
-                "question_number": 21,
-                "text": "Fake text",
-                "answer": None,
-                "category": "adm"
-            },
-            {
-                "question_number": 22,
-                "text": "Fake text",
-                "answer": None,
-                "category": "fai",
-            }
+            {"question_number": 21, "text": "Fake text", "answer": None, "category": "adm"},
+            {"question_number": 22, "text": "Fake text", "answer": None, "category": "fai"}
         ]
         self.assertEqual(expected, actual)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
     @mock.patch('app.domain.questions.Question.get_questions_by_number_range')
-    def test_correct_answers_returned_with_page_greater_than_one(self, questions_mock, attempt_mock):
+    def test_correct_answers_returned_with_page_greater_than_one(self,
+                                                                 questions_mock,
+                                                                 quiz_attempt_get_by_user_id_mock):
         question21 = Question()
         question21.text = "Fake text"
         question21.category = "adm"
@@ -290,7 +236,7 @@ class GetSurveyPageForUserIdTests(GaeTestCase):
             question22
         ]
 
-        attempt_mock.return_value.questions = [
+        quiz_attempt_get_by_user_id_mock.return_value.questions = [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10,  # Need to add all of these because in theory they would be here.
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
@@ -317,22 +263,22 @@ class GetSurveyPageForUserIdTests(GaeTestCase):
         self.assertEqual(expected, actual)
 
     @mock.patch('app.domain.questions.get_survey_page')
-    def test_prevPage_and_nextPage_set_appropriately(self, survey_mock):
-        survey_mock.return_value = []
+    def test_prevPage_and_nextPage_set_appropriately(self, get_survey_page_mock):
+        get_survey_page_mock.return_value = []
         _, prev_p, next_p = get_survey_page_for_user_id(1, 1)
         self.assertEqual(1, prev_p)
         self.assertEqual(2, next_p)
 
     @mock.patch('app.domain.questions.get_survey_page')
-    def test_prevPage_and_nextPage_set_appropriately_when_page_greater_than_one(self, survey_mock):
-        survey_mock.return_value = []
+    def test_prevPage_and_nextPage_set_appropriately_when_page_greater_than_one(self, get_survey_page_mock):
+        get_survey_page_mock.return_value = []
         _, prev_p, next_p = get_survey_page_for_user_id(5, 1)
         self.assertEqual(4, prev_p)
         self.assertEqual(6, next_p)
 
     @mock.patch('app.domain.questions.get_survey_page')
-    def test_nextPage_is_false_when_no_more_pages_to_return(self, survey_mock):
-        survey_mock.return_value = []
+    def test_nextPage_is_false_when_no_more_pages_to_return(self, get_survey_page_mock):
+        get_survey_page_mock.return_value = []
         _, prev_p, next_p = get_survey_page_for_user_id(9, 1)
         self.assertEqual(8, prev_p)
         self.assertEqual(False, next_p)
@@ -340,24 +286,26 @@ class GetSurveyPageForUserIdTests(GaeTestCase):
 
 class SaveUserSubmittedAnswersTests(GaeTestCase):
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_previous_quiz_attempt_by_user_passed_in_is_retrieved(self, attempt_mock):
+    def test_previous_quiz_attempt_by_user_passed_in_is_retrieved(self, quiz_attempt_get_by_user_id_mock):
         save_user_submitted_answers(1, [])
-        attempt_mock.assert_called_once_with(1)
+        quiz_attempt_get_by_user_id_mock.assert_called_once_with(1)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_saves_all_answers_to_attempt_if_user_attempt_is_empty_for_those_questions(self, attempt_mock):
+    def test_saves_all_answers_to_attempt_if_user_attempt_is_empty_for_those_questions(self,
+                                                                                       quiz_attempt_get_by_user_id_mock
+                                                                                       ):
         attempt = QuizAttempt(user_id=1, questions=[])
-        attempt_mock.return_value = attempt
+        quiz_attempt_get_by_user_id_mock.return_value = attempt
         save_user_submitted_answers(1, [QuizAttemptAnswer(question_number=1, answer=5)])
         self.assertEqual(1, len(attempt.questions))
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_saves_answers_over_any_attempt_answers_that_already_exist(self, attempt_mock):
+    def test_saves_answers_over_any_attempt_answers_that_already_exist(self, quiz_attempt_get_by_user_id_mock):
         attempt = QuizAttempt(user_id=1, questions=[
             QuizAttemptAnswer(question_number=1, answer=0, category='adm'),
             QuizAttemptAnswer(question_number=2, answer=5, category='adm'),
         ])
-        attempt_mock.return_value = attempt
+        quiz_attempt_get_by_user_id_mock.return_value = attempt
         save_user_submitted_answers(1, [
             QuizAttemptAnswer(question_number=1, answer=5),
             QuizAttemptAnswer(question_number=2, answer=2),
@@ -366,7 +314,7 @@ class SaveUserSubmittedAnswersTests(GaeTestCase):
         self.assertEqual(2, attempt.questions[1].answer)
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_extends_quiz_attempt_with_any_new_answers(self, attempt_mock):
+    def test_extends_quiz_attempt_with_any_new_answers(self, quiz_attempt_get_by_user_id_mock):
         attempt = QuizAttempt(user_id=1, questions=[
             QuizAttemptAnswer(question_number=1, answer=0),
             QuizAttemptAnswer(question_number=2, answer=0),
@@ -374,7 +322,7 @@ class SaveUserSubmittedAnswersTests(GaeTestCase):
             QuizAttemptAnswer(question_number=4, answer=0),
             QuizAttemptAnswer(question_number=5, answer=0),
         ])
-        attempt_mock.return_value = attempt
+        quiz_attempt_get_by_user_id_mock.return_value = attempt
         save_user_submitted_answers(1, [
             QuizAttemptAnswer(question_number=5, answer=5),
             QuizAttemptAnswer(question_number=6, answer=0),
@@ -387,13 +335,13 @@ class SaveUserSubmittedAnswersTests(GaeTestCase):
         self.assertEqual(10, len(attempt.questions))
 
     @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
-    def test_answer_not_written_if_question_numbers_dont_match(self, attempt_mock):
+    def test_answer_not_written_if_question_numbers_dont_match(self, quiz_attempt_get_by_user_id_mock):
         attempt = QuizAttempt(user_id=1, questions=[
             QuizAttemptAnswer(question_number=1, answer=0),
             QuizAttemptAnswer(question_number=2, answer=0),
             QuizAttemptAnswer(question_number=3, answer=0),
         ])
-        attempt_mock.return_value = attempt
+        quiz_attempt_get_by_user_id_mock.return_value = attempt
         save_user_submitted_answers(1, [
             QuizAttemptAnswer(question_number=1, answer=2),
             QuizAttemptAnswer(question_number=3, answer=5),

--- a/test/domain/questions_test.py
+++ b/test/domain/questions_test.py
@@ -202,6 +202,44 @@ class GetSurveyPageForUserIdTests(GaeTestCase):
         ]
         self.assertEqual(expected, actual)
 
+    @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
+    @mock.patch('app.domain.questions.Question.get_questions_by_number_range')
+    def test_no_answer_filled_in_if_question_has_not_been_answered_yet(self, questions_mock, attempt_mock):
+        question3 = Question(text="Something", question_number=3, category="adm")
+        questions_mock.return_value = [
+            self.question1,
+            self.question2,
+            question3
+        ]
+
+        attempt_mock.return_value.questions = [
+            QuizAttemptAnswer(question_number=1, answer=0),
+            QuizAttemptAnswer(question_number=3, answer=5)
+        ]
+
+        actual, _, _ = get_survey_page_for_user_id(1, 1)
+        expected = [
+            {
+                "question_number": 1,
+                "text": "Fake text",
+                "answer": 0,
+                "category": "adm"
+            },
+            {
+                "question_number": 2,
+                "text": "Fake text",
+                "answer": None,
+                "category": "fai",
+            },
+            {
+                "question_number": 3,
+                "text": "Something",
+                "answer": 5,
+                "category": "adm",
+            }
+        ]
+        self.assertEqual(expected, actual)
+
     @mock.patch('app.domain.questions.Question.get_questions_by_number_range')
     def test_correct_questions_returned_for_page_higher_than_one(self, questions_mock):
         question21 = Question()

--- a/test/domain/questions_test.py
+++ b/test/domain/questions_test.py
@@ -347,3 +347,20 @@ class SaveUserSubmittedAnswersTests(GaeTestCase):
         ])
         self.assertEqual(5, attempt.questions[4].answer)
         self.assertEqual(10, len(attempt.questions))
+
+    @mock.patch('app.domain.questions.QuizAttempt.get_by_user_id')
+    def test_answer_not_written_if_question_numbers_dont_match(self, attempt_mock):
+        attempt = QuizAttempt(user_id=1, questions=[
+            QuizAttemptAnswer(question_number=1, answer=0),
+            QuizAttemptAnswer(question_number=2, answer=0),
+            QuizAttemptAnswer(question_number=3, answer=0),
+        ])
+        attempt_mock.return_value = attempt
+        save_user_submitted_answers(1, [
+            QuizAttemptAnswer(question_number=1, answer=2),
+            QuizAttemptAnswer(question_number=3, answer=5),
+            QuizAttemptAnswer(question_number=4, answer=5),
+        ])
+        self.assertEqual(0, attempt.questions[1].answer)
+        self.assertEqual(5, attempt.questions[2].answer)
+        self.assertEqual(5, attempt.questions[3].answer)

--- a/test/models/quiz_attempt_test.py
+++ b/test/models/quiz_attempt_test.py
@@ -54,9 +54,6 @@ class QuizAttemptTests(GaeTestCase):
     def test_get_by_user_id_returns_None_when_no_attempts_exist(self):
         self.assertIsNone(QuizAttempt.get_by_user_id(100))
 
-    def test_get_by_user_id_returns_None_when_None_passed_in(self):
-        self.assertIsNone(QuizAttempt.get_by_user_id(None))
-
     def test_get_by_user_id_coerces_to_int_if_string_passed_in(self):
         with self.assertRaises(TypeError):
             QuizAttempt.get_by_user_id([1])  # Raises a TypeError when it goes to convert a list to an int.

--- a/test/views/api/v1/survey_tests.py
+++ b/test/views/api/v1/survey_tests.py
@@ -7,7 +7,7 @@ from app.views.api.v1.survey import _normalize_data
 
 
 class NormalizeDataTests(GaeTestCase):
-    def test_data_is_converted_to_list_of_namedtuples(self):
+    def test_data_is_converted_to_list_of_QuizAttemptAnswers(self):
         data = {
             '1': 'adm:2',
             '2': 'adm:5',


### PR DESCRIPTION
The title is a bit ambiguous I think, but I don't know how to put it better without writing a long form explanation. Basically what would happen is if you answered questions 1, 3, 5, and 7, if you were able to somehow** save your results and come back to page 1, it would look like questions 1, 2, 3, and 4 had answers. This was because of a bug in how I was rectifying the answers (to display) AND how I was processing them when results were submitted. Oopsy. Anyway, unit tests are in place now and things are looking better!

@gholtslander 

** I say "somehow" because you can only do this for now, when you can go to the next page (which saves your results) without filling out every question.

Oh and I also cleaned up some unit tests, removing newlines and making the mock variable names much more clear. They were confusing me from time to time so it was nigh time to do that change!